### PR TITLE
Add getClient and getBucket methods

### DIFF
--- a/spec/League/Flysystem/AwsS3v3/AwsS3AdapterSpec.php
+++ b/spec/League/Flysystem/AwsS3v3/AwsS3AdapterSpec.php
@@ -23,6 +23,16 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->beConstructedWith($this->client, $this->bucket);
     }
 
+    public function it_should_retrieve_the_bucket() 
+    {
+        $this->getBucket()->shouldBe('bucket');
+    }
+
+    public function it_should_retrieve_the_client()
+    {
+        $this->getClient()->shouldBe($this->client);
+    }
+
     public function it_is_initializable()
     {
         $this->shouldHaveType('League\Flysystem\AwsS3v3\AwsS3Adapter');

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -65,6 +65,25 @@ class AwsS3Adapter extends AbstractAdapter
     }
 
     /**
+     * Get the S3Client bucket.
+     *
+     * @return string
+     */
+    public function getBucket()
+    {
+        return $this->bucket;
+    }
+    /**
+     * Get the S3Client instance.
+     *
+     * @return S3Client
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
      * Write a new file.
      *
      * @param string $path


### PR DESCRIPTION
Add the two getter methods that are available in v2.
It's necessary to access these properties to expose
methods such as getObjectUrl.