### PR TITLE
Fixed S3Client namespace.

### DIFF
--- a/spec/League/Flysystem/AwsS3v3/AwsS3AdapterSpec.php
+++ b/spec/League/Flysystem/AwsS3v3/AwsS3AdapterSpec.php
@@ -3,7 +3,7 @@
 namespace spec\League\Flysystem\AwsS3v3;
 
 use Aws\Result;
-use Aws\S3Client;
+use Aws\S3\S3Client;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Stream\Stream;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -6,7 +6,7 @@ use Aws\Result;
 use Aws\S3\ClearBucket;
 use Aws\S3\Exception\ClearBucketException;
 use Aws\Exception\S3Exception;
-use Aws\S3Client;
+use Aws\S3\S3Client;
 use GuzzleHttp\Exception\RequestException;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;


### PR DESCRIPTION
Fixed namespace for the S3Client, received the follow error while trying to use the adapter:
```
Argument 1 passed to League\Flysystem\AwsS3v3\AwsS3Adapter::__construct() must be an instance of Aws\S3Client, instance of Aws\S3\S3Client given.
```

Running the follow versions:
- league/flysystem: 1.0.1
- league/flysystem-aws-s3-v3: 1.0.0
- aws/aws-sdk-php: 3.0.0-beta.1