### PR TITLE
`Aws\S3Client ` does not exist.

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -6,7 +6,7 @@ use Aws\Result;
 use Aws\S3\ClearBucket;
 use Aws\S3\Exception\ClearBucketException;
 use Aws\Exception\S3Exception;
-use Aws\S3Client;
+use Aws\S3\S3Client;
 use GuzzleHttp\Exception\RequestException;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;


### PR DESCRIPTION
Used the correct path for S3Client class.

`use Aws\S3\S3Client;`

Receiving following error when try to use `"aws/aws-sdk-php": "3.*@dev"` or `"aws/aws-sdk-php": "3.0.0-beta.1"`

```Catchable fatal error: Argument 1 passed to League\Flysystem\AwsS3v3\AwsS3Adapter::__construct() must be an instance of Aws\S3Client, instance of Aws\S3\S3Client given```