### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,11 @@ use League\Flysystem\Filesystem;
 
 include __DIR__ . '/vendor/autoload.php';
 
-$client = S3Client::factory([
-    'key'    => 'your-key',
-    'secret' => 'your-secret',
+$client = new S3Client([
+    'credentials' = [
+        'key'    => 'your-key',
+        'secret' => 'your-secret'
+    ],
     'region' => 'your-region',
     'version' => 'latest|version',
 ]);


### PR DESCRIPTION
Updated the way how hardcoded credentials should be passed:
http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/credentials.html#hardcoded-credentials.
Also changed client instantiation method, as `AwsClient::factory()` is [deprecated](https://github.com/aws/aws-sdk-php/blob/master/src/AwsClient.php#L346).