### PR TITLE
Filter listing when adapter is used with path prefix

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -230,7 +230,11 @@ class AwsS3Adapter extends AbstractAdapter
         /** @var Result $result */
         $result = $this->s3Client->execute($command);
 
-        return array_map([$this, 'normalizeResponse'], $result->get('Contents') ?: []);
+        $filter = function ($entry) {
+            return $entry['path'] !== false;
+        };
+
+        return array_filter(array_map([$this, 'normalizeResponse'], $result->get('Contents') ?: []), $filter);
     }
 
     /**


### PR DESCRIPTION
There was an issue when adapter was used with some path prefix. The listing returned for `/` path with  `$filesystem->listContents()` contained a weird file entry, like:

```
    array (size=7)
      'path' => boolean false
      'timestamp' => int 1433869395
      'size' => int 0
      'type' => string 'file' (length=4)
      'basename' => string '' (length=0)
      'filename' => string '' (length=0)
      'dirname' => null
```

I worked fine in adapter for AWS SDK v2, added similar filtering like there.