### PR TITLE
metaData and has() can now be retrieved for directories

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -238,10 +238,11 @@ class AwsS3Adapter extends AbstractAdapter
      * Get all the meta data of a file or directory.
      *
      * @param string $path
+     * @param bool $directory
      *
      * @return false|array
      */
-    public function getMetadata($path)
+    public function getMetadata($path, $directory = false)
     {
         $command = $this->s3Client->getCommand('headObject', [
             'Bucket' => $this->bucket,
@@ -252,6 +253,11 @@ class AwsS3Adapter extends AbstractAdapter
         try {
             $result = $this->s3Client->execute($command);
         } catch (S3Exception $exception) {
+
+            if (!$directory) {
+                return $this->getMetadata($path . "/", true);
+            }
+
             $response = $exception->getResponse();
 
             if ($response !== null && $response->getStatusCode() === 404) {


### PR DESCRIPTION
S3 has a unique issue when dealing with directories since they don't technically exist and are only files with a slash at the end.
When trying to getMetaData on directory it always returns false since S3 considers the trailing slash part of the directory name and [Filesystem strips it](https://github.com/thephpleague/flysystem/blob/master/src/Filesystem.php#L67) when normalizing the name.

Therefore it's impossible to use $fileSystem->has("folder/") without getting false.  Seems this issue is probably unique just to S3.

So to get around that limitation, if a file doesn't exist, it needs to be checked with its trailing slash.

This way it can be determined if a "directory" exists and actually get the proper metaData on it.

This addresses #33 