### PR TITLE
Added ContentLength to metaOptions

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -36,6 +36,7 @@ class AwsS3Adapter extends AbstractAdapter
         'Metadata',
         'ACL',
         'ContentType',
+        'ContentLength',
     ];
 
     /**


### PR DESCRIPTION
This will always fail as ContentLength is not an allowed option: https://github.com/thephpleague/flysystem-aws-s3-v3/blob/e8e27d07bba47d29ca064b5f9dd06273fbaf7f62/src/AwsS3Adapter.php#L505

I hence suggest adding ContentLength in.