### PR TITLE
Also handle Forbidden in ::getMetadata()

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -254,7 +254,12 @@ class AwsS3Adapter extends AbstractAdapter
         } catch (S3Exception $exception) {
             $response = $exception->getResponse();
 
-            if ($response !== null && $response->getStatusCode() === 404) {
+            if ($response !== null &&
+                (
+                    $response->getStatusCode() === 404 ||
+                    $response->getStatusCode() === 403
+                )
+            ) {
                 return false;
             }
 


### PR DESCRIPTION
This is a continuation of #29. I think I have a legitimate use case for handling this.
### Summary

Summary: when using strict policies for S3, an S3Exception with status code 403 Forbidden is thrown when the object does not exist. Allowing the `AwsS3Adapter::getMetadata()` call to handle that, fixes the present / absence checks in the Filesystem.
### In detail

We have an S3 bucket that contains a load of data for various apps. For each app ]we've restricted access to only the prefixes that are relevant for that app. Like so:

``` json
 {
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:GetObject",
                "s3:PutObject",
                "s3:DeleteObject"
            ],
            "Resource": "arn:aws:s3:::<bucket>/<app>*"
        }
    ]
}
```

Now, when performing a `has()` on a non-existing object: `<bucket>/<app>/some/prefix/to/non-existent-object`, it throws an `Aws\Exception\AwsException\S3Exception` with statuscode 403.

When the object _does_ exist, everything just works. I can perform read, write and delete on the object, as long as I make sure that getMetadata is not called.
