### PR TITLE
When copying a file, the source path needs to be url encoded

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -443,7 +443,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->client->getCommand('copyObject', [
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
-            'CopySource' => $this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey,
+            'CopySource' => urlencode($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
             'ACL' => $acl,
         ])->willReturn($copyCommand);
 
@@ -467,7 +467,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->client->getCommand('copyObject', [
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
-            'CopySource' => $this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey,
+            'CopySource' => urlencode($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
             'ACL' => 'private',
         ])->willReturn($command);
 

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -356,7 +356,7 @@ class AwsS3Adapter extends AbstractAdapter
             [
                 'Bucket' => $this->bucket,
                 'Key' => $this->applyPathPrefix($newpath),
-                'CopySource' => $this->bucket.'/'.$this->applyPathPrefix($path),
+                'CopySource' => urlencode($this->bucket.'/'.$this->applyPathPrefix($path)),
                 'ACL' => $visibility === AdapterInterface::VISIBILITY_PUBLIC ? 'public-read' : 'private',
             ]
         );


### PR DESCRIPTION
Scenario:

```php
$source = 'uploads/some+file+name.jpg';
$destination = 'doesntmatter.jpg';

$adapter->copy($source, $destination);
```

This throws an error because ultimately the pluses get converted to spaces. The guys who make the S3 library [suggest what I've done here as a solution](https://github.com/aws/aws-sdk-php/issues/236). It doesn't seem to be a problem if there are pluses in the destination as it saves that with no problem.