### PR TITLE
listContents should return all contents instead of just the last page

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -258,13 +258,13 @@ class AwsS3Adapter extends AbstractAdapter
     protected function retrievePaginatedListing(array $options)
     {
         $resultPaginator = $this->s3Client->getPaginator('ListObjects', $options);
-        $listingMerger = function (Result $result) {
-            return array_merge($result->get('Contents') ?: [], $result->get('CommonPrefixes') ?: []);
-        };
+        $listing = [];
 
-        $promise = $resultPaginator->each($listingMerger);
+        foreach ($resultPaginator as $result) {
+            $listing = array_merge($listing, $result->get('Contents') ?: [], $result->get('CommonPrefixes') ?: []);
+        }
 
-        return $promise->wait();
+        return $listing;
     }
 
     /**


### PR DESCRIPTION
aws ListObjects paginates its results by 1000.  Currently, if you call listContents on a directory that has more than 1000 files, the library will make the ListObjects request multiple times, but it will only return the last page of files. (a directory with 1032 files will make 2 aws requests but only return 32 files)