### PR TITLE
Emulate directories when calling has()

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -207,7 +207,34 @@ class AwsS3Adapter extends AbstractAdapter
     {
         $location = $this->applyPathPrefix($path);
 
-        return $this->s3Client->doesObjectExist($this->bucket, $location);
+        try {
+            $command = $this->s3Client->getCommand(
+                'headObject',
+                [
+                    'Bucket' => $this->bucket,
+                    'Key'    => $location,
+                ]
+            );
+
+            $this->s3Client->execute($command);
+
+            return true;
+        } catch (S3Exception $e) {
+            // Maybe this isn't an actual key, but a prefix.
+            // Do a prefix listing of objects to determine.
+            $command = $this->s3Client->getCommand(
+                'listObjects',
+                [
+                    'Bucket'  => $this->bucket,
+                    'Prefix'  => rtrim($location, '/').'/',
+                    'MaxKeys' => 1,
+                ]
+            );
+
+            $result = $this->s3Client->execute($command);
+
+            return $result['Contents'] || $result['CommonPrefixes'];
+        }
     }
 
     /**


### PR DESCRIPTION
If the object doesn't exist, try to list objects under it. If there are items then assume directory and return true.

This is the same logic as their [`StreamWrapper::url_stat`](https://github.com/aws/aws-sdk-php/blob/master/src/S3/StreamWrapper.php#L275-L299).

Déjà vu :laughing: :busts_in_silhouette: