### PR TITLE
Using file extension to detect MIME type when writing streamed

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -64,6 +64,28 @@ class AwsS3AdapterSpec extends ObjectBehavior
         fclose($stream);
     }
 
+    public function it_should_detect_content_type_from_path_when_write_streamed()
+    {
+        $config = new Config();
+        $path = 'foo.css';
+        $stream = tmpfile();
+        $this->client->upload(
+            $this->bucket,
+            self::PATH_PREFIX.'/'.$path,
+            $stream,
+            'private',
+            [
+                'params' => [
+                    'ContentType'   => 'text/css',
+                    'ContentLength' => 0,
+                ]
+            ]
+        )->shouldBeCalled();
+
+        $this->writeStream($path, $stream, $config)->shouldBeArray();
+        fclose($stream);
+    }
+
     public function it_should_update_files_streamed()
     {
         $stream = tmpfile();

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -11,6 +11,7 @@ use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
 use League\Flysystem\Util;
+use League\Flysystem\Util\MimeType;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
@@ -551,8 +552,16 @@ class AwsS3Adapter extends AbstractAdapter
         $options = $this->getOptionsFromConfig($config);
         $acl = isset($options['ACL']) ? $options['ACL'] : 'private';
 
-        if (!isset($options['ContentType']) && is_string($body)) {
-            $options['ContentType'] = Util::guessMimeType($path, $body);
+        if (!isset($options['ContentType'])) {
+            if (is_string($body)) {
+                $options['ContentType'] = Util::guessMimeType($path, $body);
+            }
+            if (empty($options['ContentType'])) {
+                $extension = pathinfo($path, PATHINFO_EXTENSION);
+                if ($extension) {
+                    $options['ContentType'] = MimeType::detectByFileExtension($extension) ?: 'text/plain';
+                }
+            }
         }
 
         if (!isset($options['ContentLength'])) {


### PR DESCRIPTION
Patch to resolve #54 

However, I looked twice and found out that `League\Flysystem\Util\MimeType` is declared `@internal`, hence it's public `detectByFileExtension()` should not by used by other packages, which this S3 adapter technically is. Of course I did.

I don't think it's a good idea to port the ~~method~~ class (d.r.y. and all that) nor depending to some other package which provides detection by extension. What would you prefer?
