### PR TITLE
Add lowest dependency version checking.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,16 @@ matrix:
     - php: 7.0
   fast_finish: true
 
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+
 before_install:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then rm phpspec.yml; fi;'
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then mv phpspec.no-coverage.yml phpspec.yml; fi;'
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer update --no-interaction --prefer-dist $COMPOSER_OPTS
 
 script:
   - bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "aws/aws-sdk-php": "^3.0.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^2.0.0",
+        "phpspec/phpspec": "^2.0.2",
         "henrikbjorn/phpspec-code-coverage" : "~1.0.1"
     },
     "autoload": {


### PR DESCRIPTION
I couldn't get the tests run at all until phpspec 2.0.2.
Also, Github removed its download limits on files, so there's no reason to check out from source.
