### PR TITLE
Add support for Website Redirects

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -39,6 +39,7 @@ class AwsS3Adapter extends AbstractAdapter
         'ContentEncoding',
         'ContentDisposition',
         'ContentLength',
+        'WebsiteRedirectLocation'
     ];
 
     /**


### PR DESCRIPTION
Amazon S3 provides support for hosting static sites, and as a part of that they provide support for redirects via the `x-amz-website-redirect-location` meta property. Without explicitly allowing it in the `$metaOptions` array, it gets silently stripped out.

I'm using [Jigsaw](http://jigsaw.tighten.co) to build my static site and Laravel + Flysystem to deploy it, and needed support for redirects.

http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html