### PR TITLE
Make streaming optional.

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -121,7 +121,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
             '@http' => [
-                'stream' => true,
+                'stream' => false,
             ],
         ])->willReturn($command);
 
@@ -511,7 +511,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
             '@http' => [
-                'stream' => true,
+                'stream' => false,
             ],
         ])->willReturn($command);
 

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -58,19 +58,26 @@ class AwsS3Adapter extends AbstractAdapter
     protected $options = [];
 
     /**
+     * @var bool
+     */
+    protected $stream = false;
+
+    /**
      * Constructor.
      *
      * @param S3Client $client
      * @param string   $bucket
      * @param string   $prefix
      * @param array    $options
+     * @param bool     $stream
      */
-    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
+    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [], $stream = false)
     {
         $this->s3Client = $client;
         $this->bucket = $bucket;
         $this->setPathPrefix($prefix);
         $this->options = $options;
+        $this->stream = $stream;
     }
 
     /**
@@ -432,7 +439,7 @@ class AwsS3Adapter extends AbstractAdapter
                 'Bucket' => $this->bucket,
                 'Key' => $this->applyPathPrefix($path),
                 '@http' => [
-                    'stream' => true,
+                    'stream' => $this->stream,
                 ],
             ]
         );


### PR DESCRIPTION
As mentioned in #70, adding `stream = true` breaks seeking on the file handle returned from `readStream()`.

There isn't an elegant way to have streaming and seeking, since they are opposing ideas. Meaning, the feature request:

> so this is a feature request to add options for readStream to get the seekable working.

isn't an option. The link referenced is for the S3 stream wrapper. I could not find a similar option for the normal API.

The only real way around this is to make streaming optional.

I'm changing the default from `stream = true`, to `stream = false`, since that was the default before, and defaulting to streaming has introduced bugs in user code.

I did some digging and the difference between stream = true and stream = false is what HTTP client Guzzle uses. With stream = true, Guzzle uses `fopen('http://example.com')`. With `stream = false`, Guzzle uses cURL. If either HTTP client is unavailable, then the available one is used. So this option is not a hard option, but optimistic.