### PR TITLE
Change isset to array_key_exists on ACL conf check

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -562,7 +562,7 @@ class AwsS3Adapter extends AbstractAdapter
     {
         $key = $this->applyPathPrefix($path);
         $options = $this->getOptionsFromConfig($config);
-        $acl = isset($options['ACL']) ? $options['ACL'] : 'private';
+        $acl = array_key_exists($options['ACL']) ? $options['ACL'] : 'private';
 
         if ( ! isset($options['ContentType']) && is_string($body)) {
             $options['ContentType'] = Util::guessMimeType($path, $body);

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -562,7 +562,7 @@ class AwsS3Adapter extends AbstractAdapter
     {
         $key = $this->applyPathPrefix($path);
         $options = $this->getOptionsFromConfig($config);
-        $acl = array_key_exists($options['ACL']) ? $options['ACL'] : 'private';
+        $acl = array_key_exists('ACL', $options) ? $options['ACL'] : 'private';
 
         if ( ! isset($options['ContentType']) && is_string($body)) {
             $options['ContentType'] = Util::guessMimeType($path, $body);


### PR DESCRIPTION
Now it's possible to set ACL parameter to null, thus ignoring "x-amz-acl" optional header