### PR TITLE
Added support for CloudFront and S3 integration

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -74,6 +74,20 @@ class AwsS3Adapter extends AbstractAdapter
     }
 
     /**
+     * Get the URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function getUrl($path)
+    {
+        if (isset($this->options['cloudfront'])) {
+            return $this->options['cloudfront'] . $path;
+        }
+        return $this->s3Client->getObjectUrl($this->bucket, $this->pathPrefix . $path);
+    }
+
+    /**
      * Get the S3Client bucket.
      *
      * @return string


### PR DESCRIPTION
Added support for CloudFront and S3 integration. If 'cloudfront' is defined in options (e.g. $options['cloudfront' => 'https://xxxxxxx.cloudfront.net/']) method getUrl() returns CloudFront url for the given path otherwise S3 url.