### PR TITLE
make sure options are passed where needed

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -171,7 +171,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
     {
         $key = 'key.txt';
         $result = new Result();
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(true);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(true);
 
         $this->has($key)->shouldBe(true);
     }
@@ -187,7 +187,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
                 'Key' => 'directory/foo.txt',
             ],
         ]);
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(false);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(false);
 
         $this->client->getCommand('listObjects', [
             'Bucket' => $this->bucket,
@@ -206,7 +206,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
     public function it_should_return_false_when_listing_objects_returns_a_403($command, $exception)
     {
         $key = 'directory';
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(false);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(false);
 
         $this->client->getCommand('listObjects', [
             'Bucket' => $this->bucket,
@@ -230,7 +230,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
     public function it_should_pass_through_when_listing_objects_throws_an_exception($command, $exception)
     {
         $key = 'directory';
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(false);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(false);
 
         $this->client->getCommand('listObjects', [
             'Bucket' => $this->bucket,
@@ -610,7 +610,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
 
     private function make_it_404_on_has_object($headCommand, $listCommand, $key)
     {
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(false);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(false);
 
         $result = new Result();
         $this->client->getCommand('listObjects', [

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -216,7 +216,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     {
         $location = $this->applyPathPrefix($path);
 
-        if ($this->s3Client->doesObjectExist($this->bucket, $location)) {
+        if ($this->s3Client->doesObjectExist($this->bucket, $location, $this->options)) {
             return true;
         }
 
@@ -446,7 +446,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             $options['@http'] = $this->options['@http'];
         }
 
-        $command = $this->s3Client->getCommand('getObject', $options);
+        $command = $this->s3Client->getCommand('getObject', $options + $this->options);
 
         try {
             /** @var Result $response */


### PR DESCRIPTION
https://github.com/thephpleague/flysystem/issues/787

When calling write/writeStream the Config object is created and passed through, this is then used by the adapters to pass further configuration along, but options aren't passed through when doing has/read/readStream calls. So make sure we pass them where appropriate.