### PR TITLE
Add tagging to metaOptions

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -40,6 +40,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         'ContentEncoding',
         'ContentDisposition',
         'ContentLength',
+        'Tagging',
         'WebsiteRedirectLocation',
         'SSEKMSKeyId'
     ];


### PR DESCRIPTION
In order to be able to tag objects, Tagging needs to be added to the meta options.
See https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#putobject for the full list of options