### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 matrix:
   allow_failures:


### PR DESCRIPTION
As PHP 7.1 is out since December (6 months) I think is useful to test the codebase against it.