### PR TITLE
SSE-c bug

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -218,7 +218,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     {
         $location = $this->applyPathPrefix($path);
 
-        if ($this->s3Client->doesObjectExist($this->bucket, $location)) {
+        if ($this->s3Client->doesObjectExist($this->bucket, $location, $this->options)) {
             return true;
         }
 
@@ -298,7 +298,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             [
                 'Bucket' => $this->bucket,
                 'Key' => $this->applyPathPrefix($path),
-            ]
+            ] + $this->options
         );
 
         /* @var Result $result */
@@ -442,7 +442,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         $options = [
             'Bucket' => $this->bucket,
             'Key' => $this->applyPathPrefix($path),
-        ];
+        ] + $this->options;
 
         if (isset($this->options['@http'])) {
             $options['@http'] = $this->options['@http'];


### PR DESCRIPTION
GET and HEAD method require SSE-c when the files are persisted with it. The methods has, getMetadata and readObject weren't using the necessary options. 