### PR TITLE
SSE-c bug

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -171,7 +171,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
     {
         $key = 'key.txt';
         $result = new Result();
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(true);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(true);
 
         $this->has($key)->shouldBe(true);
     }
@@ -187,7 +187,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
                 'Key' => 'directory/foo.txt',
             ],
         ]);
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(false);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(false);
 
         $this->client->getCommand('listObjects', [
             'Bucket' => $this->bucket,
@@ -206,7 +206,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
     public function it_should_return_false_when_listing_objects_returns_a_403($command, $exception)
     {
         $key = 'directory';
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(false);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(false);
 
         $this->client->getCommand('listObjects', [
             'Bucket' => $this->bucket,
@@ -610,7 +610,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
 
     private function make_it_404_on_has_object($headCommand, $listCommand, $key)
     {
-        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key)->willReturn(false);
+        $this->client->doesObjectExist($this->bucket, self::PATH_PREFIX.'/'.$key, [])->willReturn(false);
 
         $result = new Result();
         $this->client->getCommand('listObjects', [

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -218,7 +218,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     {
         $location = $this->applyPathPrefix($path);
 
-        if ($this->s3Client->doesObjectExist($this->bucket, $location)) {
+        if ($this->s3Client->doesObjectExist($this->bucket, $location, $this->options)) {
             return true;
         }
 
@@ -298,7 +298,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             [
                 'Bucket' => $this->bucket,
                 'Key' => $this->applyPathPrefix($path),
-            ]
+            ] + $this->options
         );
 
         /* @var Result $result */
@@ -442,7 +442,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         $options = [
             'Bucket' => $this->bucket,
             'Key' => $this->applyPathPrefix($path),
-        ];
+        ] + $this->options;
 
         if (isset($this->options['@http'])) {
             $options['@http'] = $this->options['@http'];


### PR DESCRIPTION
GET and HEAD method require SSE-c when the files are persisted with it. The methods has, getMetadata and readObject weren't using the necessary options.