### PR TITLE
Removed the ContentLenth param from upload method

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -572,14 +572,6 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             $options['ContentType'] = Util::guessMimeType($path, $body);
         }
 
-        if ( ! isset($options['ContentLength'])) {
-            $options['ContentLength'] = is_string($body) ? Util::contentSize($body) : Util::getStreamSize($body);
-        }
-
-        if ($options['ContentLength'] === null) {
-            unset($options['ContentLength']);
-        }
-
         $this->s3Client->upload($this->bucket, $key, $body, $acl, ['params' => $options]);
 
         return $this->normalizeResponse($options, $key);


### PR DESCRIPTION
Fixed #118 issue.
When file size exceed of 16777216 bytes (Aws\S3\ObjectUploader::DEFAULT_MULTIPART_THRESHOLD), then the S3Client use Aws\S3\MulitpartUploader and uploading each file part with wrong Content-Length header.