### PR TITLE
Update $metaOptions

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -31,19 +31,27 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
      * @var array
      */
     protected static $metaOptions = [
-        'CacheControl',
-        'Expires',
-        'StorageClass',
-        'ServerSideEncryption',
-        'Metadata',
         'ACL',
-        'ContentType',
-        'ContentEncoding',
+        'CacheControl',
         'ContentDisposition',
+        'ContentEncoding',
         'ContentLength',
+        'ContentType',
+        'Expires',
+        'GrantFullControl',
+        'GrantRead',
+        'GrantReadACP',
+        'GrantWriteACP',
+        'Metadata',
+        'RequestPayer',
+        'SSECustomerAlgorithm',
+        'SSECustomerKey',
+        'SSECustomerKeyMD5',
+        'SSEKMSKeyId',
+        'ServerSideEncryption',
+        'StorageClass',
         'Tagging',
-        'WebsiteRedirectLocation',
-        'SSEKMSKeyId'
+        'WebsiteRedirectLocation'
     ];
 
     /**


### PR DESCRIPTION
Update $metaOptions with non-required fields present on both operations
used by `S3Client->upload()` (PutObject and CreateMultipartUpload).

This also alphabetizes the list to match what is listed in the S3Client documentation.

Resolves #120 