### PR TITLE
Return StorageClass when listing files.

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -25,6 +25,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         'ContentType' => 'mimetype',
         'Size' => 'size',
         'Metadata' => 'metadata',
+        'StorageClass' => 'storageclass',
     ];
 
     /**


### PR DESCRIPTION
I am currently having an issue with files that have StorageClass = 'GLACIER'.  

FlySystem returns all files whether their StorageClass is 'STANDARD' or 'GLACIER' and I currently have no way of identifying the storage class so I can handle them differently. 