### PR TITLE
Add `versionid` to metadata field

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -27,6 +27,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         'Metadata'      => 'metadata',
         'StorageClass'  => 'storageclass',
         'ETag'          => 'etag',
+        'VersionId'     => 'versionid'
     ];
 
     /**


### PR DESCRIPTION
VersionId is missing when we enable versioning in S3 so I add this to meta data