### PR TITLE
Update and rename LICENCE to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2014 Frank de Jonge
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Legal issue: Typo in file name and missing header for clarification as per default guidelines.