### PR TITLE
Fix upload method returning path with prefix

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -456,6 +456,44 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->setVisibility($key, 'private')->shouldBe(false);
     }
 
+    /**
+     * @param \Aws\CommandInterface $command
+     */
+    public function it_should_return_path_in_response_without_prefix($command)
+    {
+        $key = 'key.txt';
+        $dir = 'dir';
+
+        $this->writeStream($key, '', new Config())->shouldHaveKeyWithValue('path', $key);
+        $this->updateStream($key, '', new Config())->shouldHaveKeyWithValue('path', $key);
+        $this->write($key, '', new Config())->shouldHaveKeyWithValue('path', $key);
+        $this->update($key, '', new Config())->shouldHaveKeyWithValue('path', $key);
+        $this->createDir($dir, new Config())->shouldHaveKeyWithValue('path', $dir);
+
+        $this->make_it_retrieve_file_metadata('getMetadata', $command);
+        $this->getMetadata($key)->shouldHaveKeyWithValue('path', $key);
+
+        $resource = tmpfile();
+        $this->make_it_read_a_file($command, 'readStream', $resource);
+        fclose($resource);
+        $this->readStream($key)->shouldHaveKeyWithValue('path', $key);
+
+        $this->make_it_read_a_file($command, 'read', '');
+        $this->read($key)->shouldHaveKeyWithValue('path', $key);
+
+        $this->client->getPaginator('ListObjects', [
+            'Bucket' => $this->bucket,
+            'Prefix' => self::PATH_PREFIX.'/'.$dir.'/',
+            'Delimiter' => '/'
+        ])->shouldBeCalled()->willReturn(new ResultPaginator(new Result([
+            'Contents' => [
+                ['Key' => self::PATH_PREFIX . '/' . $dir . '/' . $key],
+            ]
+        ])));
+
+        $this->listContents($dir)->shouldHaveItemWithKeyWithValue('path', $dir . '/' . $key);
+    }
+
     private function make_it_retrieve_raw_visibility($command, $key, $visibility)
     {
         $options = [
@@ -605,6 +643,17 @@ class AwsS3AdapterSpec extends ObjectBehavior
             },
             'haveValue' => function ($subject, $value) {
                 return in_array($value, $subject);
+            },
+            'haveItemWithKeyWithValue' => function($subject, $key, $value) {
+                foreach ($subject as $item)
+                {
+                    if (isset($item[$key]) && $item[$key] === $value)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             },
         ];
     }

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -593,7 +593,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
 
         $this->s3Client->upload($this->bucket, $key, $body, $acl, ['params' => $options]);
 
-        return $this->normalizeResponse($options, $key);
+        return $this->normalizeResponse($options, $path);
     }
 
     /**

--- a/stub/ResultPaginator.php
+++ b/stub/ResultPaginator.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Promise;
 use Aws\Result;
 use GuzzleHttp\Promise\PromiseInterface;
 
-class ResultPaginator
+class ResultPaginator implements \Iterator
 {
     /**
      * @var Result
@@ -26,5 +26,28 @@ class ResultPaginator
     public function each(callable $callback)
     {
         return Promise\promise_for($callback($this->result));
+    }
+
+    public function valid()
+    {
+        return $this->result ? true : false;
+    }
+
+    public function current()
+    {
+        return $this->valid() ? $this->result : false;
+    }
+
+    public function next()
+    {
+        $this->result = null;
+    }
+
+    public function key()
+    {
+    }
+
+    public function rewind()
+    {
     }
 }


### PR DESCRIPTION
Upload method (used in write, writeStream, update, updateStream) returns path with prefix which is inconsistent with other methods (getMetadata, read, readStream, listContents) which return path without prefix.