### PR TITLE
Invert resource check when determining content length

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -585,7 +585,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         }
 
         if ( ! isset($options['ContentLength'])) {
-            $options['ContentLength'] = is_string($body) ? Util::contentSize($body) : Util::getStreamSize($body);
+            $options['ContentLength'] = is_resource($body) ? Util::getStreamSize($body) : Util::contentSize($body);
         }
 
         if ($options['ContentLength'] === null) {


### PR DESCRIPTION
The old code caused an exception when `write()` or `update()` was called with a non-string `$body` argument (e.g. an integer, or an object with a `__toString()` method).