### PR TITLE
Fix server side copy of files with spaces in name

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -409,7 +409,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             [
                 'Bucket'     => $this->bucket,
                 'Key'        => $this->applyPathPrefix($newpath),
-                'CopySource' => urlencode($this->bucket . '/' . $this->applyPathPrefix($path)),
+                'CopySource' => rawurlencode($this->bucket . '/' . $this->applyPathPrefix($path)),
                 'ACL'        => $this->getRawVisibility($path) === AdapterInterface::VISIBILITY_PUBLIC
                     ? 'public-read' : 'private',
             ] + $this->options


### PR DESCRIPTION
Urlencode is not RFC 3986 compliant as it encodes spaces as plus (+)
signs breaking S3 implementations that expect compliant encoding. Using
rawurlencode instead fixes this.