### PR TITLE
Multipart options for upload method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 sudo: false
 

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -592,6 +592,11 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         $options = $this->getOptionsFromConfig($config);
         $acl = array_key_exists('ACL', $options) ? $options['ACL'] : 'private';
 
+        // Multipart options
+        $concurrency = array_key_exists('concurrency', $options) ? $options['concurrency'] : null;
+        $mup_threshold = array_key_exists('mup_threshold', $options) ? $options['mup_threshold'] : null;
+        $part_size = array_key_exists('part_size', $options) ? $options['part_size'] : null;
+
         if (!$this->isOnlyDir($path)) {
             if ( ! isset($options['ContentType'])) {
                 $options['ContentType'] = Util::guessMimeType($path, $body);
@@ -607,7 +612,12 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         }
 
         try {
-            $this->s3Client->upload($this->bucket, $key, $body, $acl, ['params' => $options]);
+            $this->s3Client->upload($this->bucket, $key, $body, $acl, [
+                'concurrency' => $concurrency,
+                'mup_threshold' => $mup_threshold,
+                'part_size' => $part_size,
+                'params' => $options,
+            ]);
         } catch (S3MultipartUploadException $multipartUploadException) {
             return false;
         }


### PR DESCRIPTION
This PR adds support for multipart options (concurrency, mup_threshold, part_size) in the options argument on construct. This requires no API change.

Our use case in prod requires that we customise the multipart upload options in the underlying S3Client->upload method, however previously the library did not expose these options.

Thanks!