### PR TITLE
Explicitly specify dist on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: php
-sudo: false
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+matrix:
+  include:
+    - php: 5.6
+      dist: xenial
+    - php: 7.0
+      dist: xenial
+    - php: 7.1
+      dist: bionic
+    - php: 7.2
+      dist: bionic
+    - php: 7.3
+      dist: bionic
+    - php: 7.4
+      dist: bionic
 
 install:
   - travis_retry composer install --no-interaction --prefer-source


### PR DESCRIPTION
So that the tests don't break when travis next change the default dist.