### PR TITLE
Ensure uploaded objects have their directory objects created

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -592,6 +592,12 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         $options = $this->getOptionsFromConfig($config);
         $acl = array_key_exists('ACL', $options) ? $options['ACL'] : 'private';
 
+        /* Ensure directory components exist */
+        $directory = Util::dirname($path);
+        if ($directory !== '') {
+            $this->createDir($directory, $config);
+        }
+
         if (!$this->isOnlyDir($path)) {
             if ( ! isset($options['ContentType'])) {
                 $options['ContentType'] = Util::guessMimeType($path, $body);
@@ -604,6 +610,8 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             if ($options['ContentLength'] === null) {
                 unset($options['ContentLength']);
             }
+        } else {
+            $options['ContentType'] = "application/x-directory";
         }
 
         try {


### PR DESCRIPTION
Flysystem abstraction layer createDir documentation claims:
"Directories are also made implicitly when writing to a deeper
path. In general creating a directory is not required in order
to write to it."

However the AWS S3 adapter doesn't adhere to it, under the
assumption that S3 doesn't have directories. However it is
very common to create empty objects with an appropriate
content type to signify the directories, and various tools
(e.g. s3fs-fuse) require this to function properly. Folders
manually created in the S3 console appear to behave exactly
this way as well.
Therefore replicate how S3 console and other tools do it,
by ensuring all path components exist and the directory
objects are forced to the correct content type.