### PR TITLE
Fix the minimum version required to support php 7.4 breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.5.0",
         "league/flysystem": "^1.0.40",
-        "aws/aws-sdk-php": "^3.0.0"
+        "aws/aws-sdk-php": "^3.133.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.0.0",


### PR DESCRIPTION
**Purpose:**
`aws-sdk-php` package throws null error when using php7.4 version. So they have fixed this in the release of 3.133.0 and the concerning PR can be found at https://github.com/aws/aws-sdk-php/pull/1916 

**Solution:**
Updating the minimum version requirement for `aws-sdk-php` package in composer.json to support the php7.4 version.