### PR TITLE
Feature/make use of s3clientinterface

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ composer require league/flysystem-aws-s3-v3
 
 # Bootstrap
 
+Using standard `Aws\S3\S3Client`:
+
 ``` php
 <?php
 use Aws\S3\S3Client;
@@ -32,6 +34,28 @@ $client = new S3Client([
         'secret' => 'your-secret'
     ],
     'region' => 'your-region',
+    'version' => 'latest|version',
+]);
+
+$adapter = new AwsS3Adapter($client, 'your-bucket-name');
+$filesystem = new Filesystem($adapter);
+```
+
+or using `Aws\S3\S3MultiRegionClient` which does not require to specify the `region` parameter:
+
+``` php
+<?php
+use Aws\S3\S3MultiRegionClient;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Filesystem;
+
+include __DIR__ . '/vendor/autoload.php';
+
+$client = new S3Client([
+    'credentials' => [
+        'key'    => 'your-key',
+        'secret' => 'your-secret'
+    ],
     'version' => 'latest|version',
 ]);
 

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ use League\Flysystem\Filesystem;
 
 include __DIR__ . '/vendor/autoload.php';
 
-$client = new S3Client([
+$client = new S3MultiRegionClient([
     'credentials' => [
         'key'    => 'your-key',
         'secret' => 'your-secret'

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -6,7 +6,7 @@ use Aws\Result;
 use Aws\S3\Exception\DeleteMultipleObjectsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\Exception\S3MultipartUploadException;
-use Aws\S3\S3Client;
+use Aws\S3\S3ClientInterface;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\Adapter\CanOverwriteFiles;
 use League\Flysystem\AdapterInterface;
@@ -59,7 +59,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     ];
 
     /**
-     * @var S3Client
+     * @var S3ClientInterface
      */
     protected $s3Client;
 
@@ -76,12 +76,12 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     /**
      * Constructor.
      *
-     * @param S3Client $client
+     * @param S3ClientInterface $client
      * @param string   $bucket
      * @param string   $prefix
      * @param array    $options
      */
-    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
+    public function __construct(S3ClientInterface $client, $bucket, $prefix = '', array $options = [])
     {
         $this->s3Client = $client;
         $this->bucket = $bucket;
@@ -112,7 +112,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     /**
      * Get the S3Client instance.
      *
-     * @return S3Client
+     * @return S3ClientInterface
      */
     public function getClient()
     {


### PR DESCRIPTION
This PR suggest to make use an instance of the AWS\S3\S3ClientInterface instead of AWS\S3\S3Client when creating AwsS3Adapter. That will inprove the flexibility allowing any descendants (not only S3Client, but also S3MultiRegionClient, which is more  convenient in some cases).