### PR TITLE
urlencode when normalize response

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -674,7 +674,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     {
         $result = [
             'path' => $path ?: $this->removePathPrefix(
-                isset($response['Key']) ? $response['Key'] : $response['Prefix']
+                isset($response['Key']) ? urldecode($response['Key']) : urldecode($response['Prefix'])
             ),
         ];
         $result = array_merge($result, Util::pathinfo($result['path']));


### PR DESCRIPTION
I have some issues with this library with some aws s3 compatible object storage service like ufile which provided by ucloud. their api response may convert '/' to '%2F', it will make the library not work normal. so urldecode the response may be a good solution. i have tested it and it works fine now.