### PR TITLE
Replace rawurlencode with S3Client::encodeKey

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -7,6 +7,7 @@ use Aws\Result;
 use Aws\S3\Exception\DeleteMultipleObjectsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\Exception\S3MultipartUploadException;
+use Aws\S3\S3Client;
 use GuzzleHttp\Psr7;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
@@ -624,7 +625,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->client->getCommand('copyObject', [
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
-            'CopySource' => urlencode($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
+            'CopySource' => S3Client::encodeKey($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
             'ACL' => $acl,
         ])->willReturn($copyCommand);
 
@@ -648,7 +649,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->client->getCommand('copyObject', [
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
-            'CopySource' => urlencode($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
+            'CopySource' => S3Client::encodeKey($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
             'ACL' => 'private',
         ])->willReturn($command);
 

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -6,6 +6,7 @@ use Aws\Result;
 use Aws\S3\Exception\DeleteMultipleObjectsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\Exception\S3MultipartUploadException;
+use Aws\S3\S3Client;
 use Aws\S3\S3ClientInterface;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\Adapter\CanOverwriteFiles;
@@ -421,7 +422,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             [
                 'Bucket'     => $this->bucket,
                 'Key'        => $this->applyPathPrefix($newpath),
-                'CopySource' => rawurlencode($this->bucket . '/' . $this->applyPathPrefix($path)),
+                'CopySource' => S3Client::encodeKey($this->bucket . '/' . $this->applyPathPrefix($path)),
                 'ACL'        => $this->getRawVisibility($path) === AdapterInterface::VISIBILITY_PUBLIC
                     ? 'public-read' : 'private',
             ] + $this->options


### PR DESCRIPTION
Implements the suggestion posed in #200 to fix problems with the `copy` method using DigitalOcean Spaces by replacing `rawurlencode` with the [S3Client::encodeKey](https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.S3.S3Client.html#_encodeKey) method from the AWS SDK.