### PR TITLE
Make dependency to the core library less strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": "^7.2",
-        "league/flysystem": "2.0.0-alpha.3",
+        "league/flysystem": "^2.0.0-alpha.3",
         "league/mime-type-detection": "^1.0.0",
         "aws/aws-sdk-php": "^3.132.4"
     },


### PR DESCRIPTION
Thats funny but currently there is no possibility to install aws adapter 2.0.0-beta.1 together with Flysystem 2.0.0-beta.1 without composer versioning hack)