### PR TITLE
Bugfix - Make sure readStream actually reads a stream

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -569,10 +569,16 @@ class AwsS3AdapterSpec extends ObjectBehavior
             'LastModified' => $date = date('Y-m-d h:i:s'),
             'Body' => $stream,
         ]);
-        $this->client->getCommand('getObject', [
-            'Bucket' => $this->bucket,
-            'Key' => self::PATH_PREFIX.'/'.$key,
-        ])->willReturn($command);
+	    $config = [
+		    'Bucket' => $this->bucket,
+		    'Key'    => self::PATH_PREFIX.'/'.$key,
+	    ];
+	    
+	    if ($method === 'readStream') {
+	    	$config['@http'] = ['stream' => true];
+	    }
+	    
+	    $this->client->getCommand('getObject', $config)->willReturn($command);
 
         $this->client->execute($command)->willReturn($result);
         $this->{$method}($key)->shouldBeArray();

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -248,7 +248,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
      */
     public function read($path)
     {
-        $response = $this->readObject($path);
+        $response = $this->readObject($path,false);
 
         if ($response !== false) {
             $response['contents'] = $response['contents']->getContents();
@@ -446,7 +446,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
      */
     public function readStream($path)
     {
-        $response = $this->readObject($path);
+        $response = $this->readObject($path, true);
 
         if ($response !== false) {
             $response['stream'] = $response['contents']->detach();
@@ -455,20 +455,24 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
 
         return $response;
     }
-
-    /**
-     * Read an object and normalize the response.
-     *
-     * @param string $path
-     *
-     * @return array|bool
-     */
-    protected function readObject($path)
+	
+	/**
+	 * Read an object and normalize the response.
+	 *
+	 * @param string $path
+	 * @param bool   $stream
+	 * @return array|bool
+	 */
+    protected function readObject($path, $stream)
     {
         $options = [
             'Bucket' => $this->bucket,
             'Key'    => $this->applyPathPrefix($path),
         ];
+        
+        if ($stream) {
+        	$options['@http']['stream'] = true;
+        }
 
         if (isset($this->options['@http'])) {
             $options['@http'] = $this->options['@http'];

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -248,7 +248,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
      */
     public function read($path)
     {
-        $response = $this->readObject($path,false);
+        $response = $this->readObject($path, false);
 
         if ($response !== false) {
             $response['contents'] = $response['contents']->getContents();

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -463,7 +463,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
    * @param bool   $stream
    * @return array|bool
    */
-    protected function readObject($path, $stream)
+    protected function readObject($path, $stream = true)
     {
         $options = [
             'Bucket' => $this->bucket,

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -455,14 +455,14 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
 
         return $response;
     }
-	
-	/**
-	 * Read an object and normalize the response.
-	 *
-	 * @param string $path
-	 * @param bool   $stream
-	 * @return array|bool
-	 */
+  
+  /**
+   * Read an object and normalize the response.
+   *
+   * @param string $path
+   * @param bool   $stream
+   * @return array|bool
+   */
     protected function readObject($path, $stream)
     {
         $options = [

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -455,7 +455,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
 
         return $response;
     }
-  
+
   /**
    * Read an object and normalize the response.
    *


### PR DESCRIPTION
# Problem

By default `readStream` does not stream data from S3 itself but it will download the whole file into memory and pass a stream resource to that data in local memory. If you want to stream data directly from S3 you will need to pass (a strangely undocumented) option in the constructor as per suggestion here: https://github.com/thephpleague/flysystem-aws-s3-v3/issues/124#issuecomment-330589497

However if this option is passed via the constructor then `writeStream` will fail with an exception as described here: https://github.com/thephpleague/flysystem-aws-s3-v3/issues/209

# Proposed Solution

By default always assume that `readStream` means that the client wants to stream directly from S3 and always pass the aforementioned option when calling the S3 sdk. The order is done in such a way that setting this option via the constructor will have precedence over the default.