### PR TITLE
Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "league/flysystem": "^2.0.0-RC1",
         "league/mime-type-detection": "^1.0.0",
         "aws/aws-sdk-php": "^3.132.4"


### PR DESCRIPTION
Allows the package to be installed on PHP 8. This also allows us to test the Flysystem v2 PR for Laravel 9 on PHP 8: https://github.com/laravel/framework/pull/33612