### PR TITLE
Use $config in copy operation

### DIFF
--- a/AwsS3V3Adapter.php
+++ b/AwsS3V3Adapter.php
@@ -392,6 +392,8 @@ class AwsS3V3Adapter implements FilesystemAdapter
                 $exception
             );
         }
+        
+        $options = $this->createOptionsFromConfig($config);
 
         try {
             $this->client->copy(
@@ -400,7 +402,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
                 $this->bucket,
                 $this->prefixer->prefixPath($destination),
                 $this->visibility->visibilityToAcl($visibility),
-                $this->options
+                $options
             );
         } catch (Throwable $exception) {
             throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);


### PR DESCRIPTION
I noticed that when copying a file, the `$config` param is not used. This is a problem if you require the object to be encrypted, for example.