### PR TITLE
Optional logging of exception messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": ">=5.5.0",
         "league/flysystem": "^1.0.40",
-        "aws/aws-sdk-php": "^3.20.0"
+        "aws/aws-sdk-php": "^3.20.0",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.0.0",

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -6,7 +6,6 @@ use Aws\Result;
 use Aws\S3\Exception\DeleteMultipleObjectsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\Exception\S3MultipartUploadException;
-use Aws\S3\S3Client;
 use Aws\S3\S3ClientInterface;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Adapter\AbstractAdapter;


### PR DESCRIPTION
Hi I ran into some issues where it would be helpful to be able to know why certain actions fail using the adapter.
To overcome that hurdle I implemented the basic PSR-3 pattern of optionally passing a logger to the constructor that uses the `NullLogger` when there is no logger passed.