### PR TITLE
Fix: Pass params to copy method

### DIFF
--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -681,7 +681,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
             $this->bucket,
             self::PATH_PREFIX.'/'.$key,
             $acl,
-            []
+            ['params' => []]
         )->shouldBeCalled();
     }
 
@@ -705,7 +705,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
             $this->bucket,
             self::PATH_PREFIX.'/'.$key,
             'private',
-            []
+            ['params' => []]
         )->willThrow(S3Exception::class);
     }
 

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -423,7 +423,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
                 $this->applyPathPrefix($newpath),
                 $this->getRawVisibility($path) === AdapterInterface::VISIBILITY_PUBLIC
                     ? 'public-read' : 'private',
-                $this->options
+                ['params' => $this->options]
             );
         } catch (S3Exception $e) {
             return false;


### PR DESCRIPTION
We use SSE-C and needs to forward parameters to the copy method encapsulated in a params array key.