### PR TITLE
Add Content-MD5 when uploading

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -601,14 +601,14 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
                 unset($options['ContentLength']);
             }
             
-            if (! isset($options['Content-MD5'])) {
+            if (! isset($options['ContentMD5'])) {
                 if (is_resource($body)) {
                     $ctx = hash_init('MD5');
                     hash_update_stream($ctx, $body);
                     rewind($body);
-                    $options['Content-MD5'] = base64_encode(hash_final($ctx, true));
+                    $options['ContentMD5'] = base64_encode(hash_final($ctx, true));
                 } else {
-                    $options['Content-MD5'] = base64_encode(md5($body, true));
+                    $options['ContentMD5'] = base64_encode(md5($body, true));
                 }
             }
         }

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -600,6 +600,17 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             if ($options['ContentLength'] === null) {
                 unset($options['ContentLength']);
             }
+            
+            if (! isset($options['Content-MD5'])) {
+                if (is_resource($body)) {
+                    $ctx = hash_init('MD5');
+                    hash_update_stream($ctx, $body);
+                    rewind($body);
+                    $options['Content-MD5'] = base64_encode(hash_final($ctx, true));
+                } else {
+                    $options['Content-MD5'] = base64_encode(md5($body, true));
+                }
+            }
         }
 
         try {


### PR DESCRIPTION
When uploading to a S3 bucket with object lock enabled, this could result in the following error:
```
Content-MD5 HTTP header is required for Put Object requests with Object Lock parameters
```

This PR adds this param. 