### PR TITLE
Allow for Integrity check of Uploaded Files

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -41,6 +41,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         'ContentDisposition',
         'ContentEncoding',
         'ContentLength',
+        'ContentMD5',
         'ContentType',
         'Expires',
         'GrantFullControl',


### PR DESCRIPTION
Adding the `ContentMD5` option to the list of allowable values, enables developers to pass in a base64 encoded MD5 of the file they are uploading. AWS will then check that against its own uploaded file, and return an error if the MD5 values don't match.

[See Here for Details](https://aws.amazon.com/premiumsupport/knowledge-center/data-integrity-s3/)