### PR TITLE
fix: ErrorException: ltrim(): Passing null to parameter #1 ($string) …

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -535,7 +535,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
      */
     public function setPathPrefix($prefix)
     {
-        $prefix = ltrim($prefix, '/');
+        $prefix = ltrim((string) $prefix, '/');
 
         return parent::setPathPrefix($prefix);
     }


### PR DESCRIPTION
…of type string is deprecated in src/AwsS3Adapter.php:537