### PR TITLE
Fix failed to get ACL from config

### DIFF
--- a/AwsS3V3Adapter.php
+++ b/AwsS3V3Adapter.php
@@ -170,7 +170,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
     {
         $key = $this->prefixer->prefixPath($path);
         $options = $this->createOptionsFromConfig($config);
-        $acl = $options['ACL'] ?? $this->determineAcl($config);
+        $acl = $options['params']['ACL'] ?? $this->determineAcl($config);
         $shouldDetermineMimetype = $body !== '' && ! array_key_exists('ContentType', $options['params']);
 
         if ($shouldDetermineMimetype && $mimeType = $this->mimeTypeDetector->detectMimeType($key, $body)) {


### PR DESCRIPTION
Issue description: fails to set ACL header from config object.

The createOptionsFromConfig() method appends config to the "params" key, getting the ACL using $options['params']['ACL'] instead of $options['ACL'] fixed the issue.