### PR TITLE
Add proper reason to UnableToWriteFile exception

### DIFF
--- a/AwsS3V3Adapter.php
+++ b/AwsS3V3Adapter.php
@@ -182,7 +182,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
         try {
             $this->client->upload($this->bucket, $key, $body, $acl, $options);
         } catch (Throwable $exception) {
-            throw UnableToWriteFile::atLocation($path, '', $exception);
+            throw UnableToWriteFile::atLocation($path, $exception->getMessage(), $exception);
         }
     }
 


### PR DESCRIPTION
Now, in the event of an error 'Unable to write file at location', it is not clear what caused it