### PR TITLE
Determine MimeType when file contents empty

### DIFF
--- a/AwsS3V3Adapter.php
+++ b/AwsS3V3Adapter.php
@@ -173,7 +173,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
         $key = $this->prefixer->prefixPath($path);
         $options = $this->createOptionsFromConfig($config);
         $acl = $options['params']['ACL'] ?? $this->determineAcl($config);
-        $shouldDetermineMimetype = $body !== '' && ! array_key_exists('ContentType', $options['params']);
+        $shouldDetermineMimetype = ! array_key_exists('ContentType', $options['params']);
 
         if ($shouldDetermineMimetype && $mimeType = $this->mimeTypeDetector->detectMimeType($key, $body)) {
             $options['params']['ContentType'] = $mimeType;


### PR DESCRIPTION
When upgrading to Laravel 9, I noticed that the MimeType is no longer recognized correctly for empty file contents.
In previous versions, the MimeType was also recognized for empty files based on the file extension.


