### PR TITLE
Fix access to private constant (fixes #252).

### DIFF
--- a/AwsS3V3Adapter.php
+++ b/AwsS3V3Adapter.php
@@ -311,7 +311,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
     {
         $extracted = [];
 
-        foreach (static::EXTRA_METADATA_FIELDS as $field) {
+        foreach (self::EXTRA_METADATA_FIELDS as $field) {
             if (isset($metadata[$field]) && $metadata[$field] !== '') {
                 $extracted[$field] = $metadata[$field];
             }


### PR DESCRIPTION
Fixes #252: Access private constant with `self::` instead of `static::`.