### PR TITLE
Bump `aws/aws-sdk-php` version to ^3.368.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0.2",
         "league/flysystem": "^3.10.0",
         "league/mime-type-detection": "^1.0.0",
-        "aws/aws-sdk-php": "^3.295.10"
+        "aws/aws-sdk-php": "^3.368.0"
     },
     "conflict": {
         "guzzlehttp/ringphp": "<1.1.1",


### PR DESCRIPTION
As we have [Security Advisory](https://github.com/aws/aws-sdk-php/security/advisories/GHSA-x8cp-jf6f-r4xh) on `aws/aws-sdk-php` package.