### PR TITLE
Update aws/aws-sdk-php version to ^3.356.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0.2",
         "league/flysystem": "^3.10.0",
         "league/mime-type-detection": "^1.0.0",
-        "aws/aws-sdk-php": "^3.295.10"
+        "aws/aws-sdk-php": "^3.356.19"
     },
     "conflict": {
         "guzzlehttp/ringphp": "<1.1.1",


### PR DESCRIPTION
To mitigate CVE-2025-14764 aws-sdk-php is updated.